### PR TITLE
Upgrade to Debian Buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,13 @@
-FROM debian:stable
-
-ARG APTLY_VERSION=1.3.0
+FROM debian:buster-slim
 
 LABEL maintainer="lukas.steiner@steinheilig.de"
 LABEL repository="github.com/lu1as/docker-aptly"
-LABEL version=${APTLY_VERSION}
 
 RUN apt-get update \
-    && apt-get install -y gnupg1 gpgv1 cron sudo \
-    && echo "deb http://repo.aptly.info/ squeeze main" > /etc/apt/sources.list.d/aptly.list \
-    && apt-key adv --fetch-keys https://www.aptly.info/pubkey.txt \
-    && apt-get update \
-    && apt-get install -y aptly=${APTLY_VERSION} \
+    && apt-get upgrade -y \
+    && apt-get install -y cron sudo gnupg1 aptly \
     && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && useradd -m -d /aptly -s /bin/bash aptly \
     && echo "aptly ALL=NOPASSWD: ALL" >> /etc/sudoers
 


### PR DESCRIPTION
* Uses buster-slim
* Uses aptly from Debian now, as 1.3.0 is now in Buster
* Cleanup of /var/lib/apt/lists/ after build, so the image gets smaller